### PR TITLE
update 104 config setting

### DIFF
--- a/client/core.go
+++ b/client/core.go
@@ -362,6 +362,8 @@ func newClientOption(settings *Settings) *cs104.ClientOption {
 	opts := cs104.NewOption()
 	if settings.Cfg104 == nil {
 		opts.SetConfig(cs104.DefaultConfig())
+	} else {
+		opts.SetConfig(*settings.Cfg104)
 	}
 	if settings.Params == nil {
 		opts.SetParams(asdu.ParamsWide)


### PR DESCRIPTION
当有传入104相关设置时，应当带入到 `cs104.ClientOption` 中